### PR TITLE
Table-nested images appear stretched in Safari (desktop and mobile)

### DIFF
--- a/_sass/papers.scss
+++ b/_sass/papers.scss
@@ -218,6 +218,11 @@
       }
       th[scope=col] { font-weight: bold; }
       th[scope=row] { font-style: italic;}
+
+      td > img {
+        height: auto;
+        object-fit: contain;
+      }
     }
   }
 


### PR DESCRIPTION
See screenshots below. This only appears to be an issue in Safari, and when the `img` is nested within a `td` table cell. Otherwise images appear as expected in Chrome, Firefox. (Thus, as the only paper page with table-nested images, this issue so far only appears in vis-text-model.) Including a minimally-invasive fix that targets just these instances.
![safari-stretched-img](https://user-images.githubusercontent.com/2343316/235750498-188b3975-b90f-462c-9f26-bf96039bc6e7.jpg)