### PR TITLE
add venue info to citation metadata

### DIFF
--- a/_layouts/pub.html
+++ b/_layouts/pub.html
@@ -12,6 +12,8 @@
     {% assign venue_type = site.data.venues[page.venue].bibtex.venue %}
     {% if venue_type == 'journal' %}
       <meta name="citation_journal_title" content="{{site.data.venues[page.venue].full | default:page.venue}}">
+    {% elsif venue_type == 'institute' %}
+      <meta name="citation_technical_report_institution" content="{{site.data.venues[page.venue].full | default:page.venue}}">
     {% else %}
       <meta name="citation_inbook_title" content="{{site.data.venues[page.venue].full | default:page.venue}}">
     {% endif %}

--- a/_layouts/pub.html
+++ b/_layouts/pub.html
@@ -8,6 +8,14 @@
   {% if page.doi %}
     <meta name="citation_doi" content="{{page.doi}}">
   {% endif %}
+  {% if page.venue %}
+    {% assign venue_type = site.data.venues[page.venue].bibtex.venue %}
+    {% if venue_type == 'journal' %}
+      <meta name="citation_journal_title" content="{{site.data.venues[page.venue].full | default:page.venue}}">
+    {% else %}
+      <meta name="citation_inbook_title" content="{{site.data.venues[page.venue].full | default:page.venue}}">
+    {% endif %}
+  {% endif %}
 
   {% for author in page.authors %}
     {% assign person = site.data.people[author.key] %}
@@ -34,7 +42,7 @@
   <script type="text/javascript">
     document.addEventListener('DOMContentLoaded', function() {
       const bibtex = document.getElementById('bibtex').innerText;
-      
+
       // Copy Bibtext
       document.getElementById('bib-copy').addEventListener('click', function(evt) {
         const setText = (txt) => () => {
@@ -71,7 +79,7 @@
               {% assign person_url = author.url | default:person.url %}
               <p class="pure-u-1-2 pure-u-md-1-4">
                 {% if person_url %}<a href="{{person_url}}">{% endif %}
-                {% if person %}<img src="/imgs/people/{{author.key}}.jpg" alt="" />{% endif %}  
+                {% if person %}<img src="/imgs/people/{{author.key}}.jpg" alt="" />{% endif %}
                 <span class="name">{{author.name | default:person.name}}{% if author.equal %}*{% endif %}</span>
                 <span class="affiliation">
                   {% if person %}
@@ -142,7 +150,7 @@
 
           {% unless page.preprint %}
             <h4>
-              Bibtex 
+              Bibtex
               <a id="bib-copy" class="bib" href="#" title="Copy Bibtex"><i class="far fa-copy" aria-hidden="true"></i></a>
               <a id="bib-download" class="bib" href="#" title="Download Bibtex"><i class="far fa-arrow-alt-circle-down" aria-hidden="true"></i></a>
             </h4>
@@ -152,7 +160,7 @@
 
           {% if page.videos.size > 0 %}
             <h4>Videos</h4>
-            
+
             {% for video in page.videos %}
               <h5>{{video.name}}</h5>
               <div class="video-wrapper">

--- a/_pubs/rich-screen-reader-vis-experiences.md
+++ b/_pubs/rich-screen-reader-vis-experiences.md
@@ -15,6 +15,7 @@ authors:
     url: https://www.disabilityinnovation.com/who-we-are/our-team/daniel-hajas
   - key: arvindsatya
 venue: eurovis
+doi: 10.1111/cgf.14519
 year: 2022
 date: 2022-06-13
 award: honMention


### PR DESCRIPTION
I added some code to the pubs template to add citation metadata for the venue information, so that when you e.g. import one of our html papers into zotero the publication venue will be populated. I also added the DOI to the rich screen reader paper