### PR TITLE
fix centering of "level 2" in semantic levels table

### DIFF
--- a/_pubs/vis-text-model.md
+++ b/_pubs/vis-text-model.md
@@ -21,6 +21,7 @@ materials:
     url: /pubs/vis-text-model/data
     type: file
 ---
+
 <style>
   figure#S4\.T3 tbody {
     font-size: 0.8em;
@@ -28,8 +29,8 @@ materials:
   }
 </style>
 <article>
-  <figure id="teaser"><img src="x32.png" id="p1.g1" class="ltx_graphics ltx_centering" width="2702" height="588" 
-    alt="A three-column horizontal teaser graphic. Column A contains the famous “Flatten the Curve” coronavirus chart. Columns B and C contain different descriptions of that chart. A long description is available at the following link." 
+  <figure id="teaser"><img src="x32.png" id="p1.g1" class="ltx_graphics ltx_centering" width="2702" height="588"
+    alt="A three-column horizontal teaser graphic. Column A contains the famous “Flatten the Curve” coronavirus chart. Columns B and C contain different descriptions of that chart. A long description is available at the following link."
     longdesc="fig-teaser-longdesc.html"/>
     <a href="fig-teaser-longdesc.html" class="ltx_align_center" target="_">Long Description</a>
     <figcaption class="ltx_text ltx_caption ltx_align_center">
@@ -353,7 +354,7 @@ materials:
               reference to the rendered visualization and “common knowledge” (<emph class="ltx_emph ltx_font_italic">perceiver-dependent</emph>)</td>
           </tr>
           <tr class="ltx_tr">
-            <td class="ltx_td ltx_align_left ltx_wrap ltx_align_middle" style="width:5.7pt;padding-top:3.472222222222222px;padding-bottom:3.472222222222222px; background-color:#94DE94;">
+            <td class="ltx_td ltx_align_center ltx_align_middle" style="width:5.7pt;padding-top:3.472222222222222px;padding-bottom:3.472222222222222px; background-color:#94DE94;">
               <span class="ltx_text ltx_wrap ltx_font_typewriter">Level 2</span>
             </td>
             <td class="ltx_td ltx_align_left ltx_wrap ltx_align_middle" style="width:71.1pt;padding-top:3.472222222222222px;padding-bottom:3.472222222222222px; background-color:#F2FFEB;">


### PR DESCRIPTION
before:

<img width="611" alt="Screenshot 2023-08-09 at 3 37 16 PM" src="https://github.com/mitvis/website/assets/4650077/24a1d307-093d-44d7-9d81-5d4e62f507c3">

after:

<img width="620" alt="Screenshot 2023-08-09 at 3 37 10 PM" src="https://github.com/mitvis/website/assets/4650077/f66ba3d6-39b8-475f-91fd-d2f7781b7ffb">
