### PR TITLE
correct bibtex generation

### DIFF
--- a/src/lib/components/Bibtex.svelte
+++ b/src/lib/components/Bibtex.svelte
@@ -39,7 +39,7 @@
 </h3>
 
 <div class="text-xs bg-stone-100 rounded-md p-2 mb-4 overflow-x-auto">
-  <pre bind:this={bibtex}>@{venue.bibtex.type}&lbrace;{displayYear}-{slug}
+  <pre bind:this={bibtex}>@{venue.bibtex.type}&lbrace;{displayYear}-{slug},
   title = &lbrace;&lbrace;{escape(pub.fullTitle)}&rbrace;&rbrace;,
   author = &lbrace;{escape(authors)}&rbrace;,
   {venue.bibtex.venue} = &lbrace;{escape(venue.full)}&rbrace;,


### PR DESCRIPTION
Before:

```
@article{2026-gofish
  title = {{GoFish: A Grammar of More Graphics!}},
  author = {Josh Pollock AND Arvind Satyanarayan},
  journal = {IEEE Transactions on Visualization \& Computer Graphics (Proc. IEEE VIS)},
  year = {2026},
  url = {https://vis.csail.mit.edu/pubs/gofish}
}
```

After:

```
@article{2026-gofish,
  title = {{GoFish: A Grammar of More Graphics!}},
  author = {Josh Pollock AND Arvind Satyanarayan},
  journal = {IEEE Transactions on Visualization \& Computer Graphics (Proc. IEEE VIS)},
  year = {2026},
  url = {https://vis.csail.mit.edu/pubs/gofish}
}
```

h/t Matt Beaudouin-Lafon for noticing!